### PR TITLE
[WIP] Add Implementation of ConfigClient

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - bash -x scripts/travis/goConstChecker.sh
     - stage: GoLint Checker
       script:
-        - go get -u github.com/golang/lint/golint
+        - mkdir -p $GOPATH/src/golang.org/x && git clone https://github.com/golang/lint.git $GOPATH/src/golang.org/x/lint && go get golang.org/x/lint/golint
         - bash -x scripts/travis/goLintChecker.sh
     - stage: GoCyclo Checker
       script:

--- a/apollo-client/apollo_client.go
+++ b/apollo-client/apollo_client.go
@@ -1,0 +1,140 @@
+package apolloclient
+
+import (
+	"errors"
+	"github.com/ServiceComb/go-cc-client/serializers"
+	"github.com/ServiceComb/go-chassis/core/config"
+	"github.com/ServiceComb/go-chassis/core/lager"
+	"github.com/ServiceComb/http-client"
+	"io/ioutil"
+	"net/http"
+	"strings"
+)
+
+// ApolloClient contains the implementation of ConfigClient
+type ApolloClient struct {
+	name   string
+	client *httpclient.URLClient
+}
+
+const apolloServerAPI = ":ServerURL/configs/:appID/:clusterName/:nameSpace"
+const defaultContentType = "application/json"
+
+// NewApolloClient init's the necessary objects needed for seamless communication to apollo Server
+func (apolloClient *ApolloClient) NewApolloClient() {
+	options := &httpclient.URLClientOption{
+		SSLEnabled: false,
+		TLSConfig:  nil, //TODO Analyse the TLS configuration of Apollo Server
+		Compressed: false,
+		Verbose:    false,
+	}
+	var err error
+	apolloClient.client, err = httpclient.GetURLClient(options)
+	if err != nil {
+		lager.Logger.Error("ApolloClient Initialization Failed", err)
+	}
+	lager.Logger.Debugf("ApolloClient Initialized successfully")
+}
+
+// HTTPDo Use http-client package for rest communication
+func (apolloClient *ApolloClient) HTTPDo(method string, rawURL string, headers http.Header, body []byte) (resp *http.Response, err error) {
+	return apolloClient.client.HttpDo(method, rawURL, headers, body)
+}
+
+// PullConfigs is the implementation of ConfigClient and pulls all the configuration for a given serviceName
+func (apolloClient *ApolloClient) PullConfigs(serviceName, version, app, env string) (map[string]interface{}, error) {
+	/*
+		1. Compose the URL
+		2. Make a Http Request to Apollo Server
+		3. Unmarshal the response
+		4. Return back the configuration/error
+		Note: Currently the input to this function in not used, need to check it's feasibility of using it, as the serviceName/version can be different in Apollo
+	*/
+
+	// Compose the URL
+	pullConfigurationURL := composeURL()
+
+	// Make a Http Request to Apollo Server
+	resp, err := apolloClient.HTTPDo("GET", pullConfigurationURL, nil, nil)
+	if err != nil {
+		lager.Logger.Error("Error in Querying the Response from Apollo", err)
+		return nil, err
+	}
+	/*
+		Sample Response from Apollo Server
+		{
+			"appId": "SampleApp",
+			"cluster": "default",
+			"namespaceName": "application",
+			"configurations": {
+				"timeout": "500"
+			},
+			"releaseKey": "20180327130726-1dc5027439679153"
+		}
+	*/
+
+	//Unmarshal the response
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	var configurations map[string]interface{}
+	error := serializers.Decode(defaultContentType, body, &configurations)
+	if error != nil {
+		lager.Logger.Error("Error in Unmarshalling the Response from Apollo", error)
+		return nil, err
+	}
+
+	lager.Logger.Debugf("The Marshaled response of the body is : ", configurations["configurations"])
+
+	return configurations, nil
+}
+
+// PullConfig is the implementation of the ConfigClient
+func (apolloClient *ApolloClient) PullConfig(serviceName, version, app, env, key, contentType string) (interface{}, error) {
+	/*
+			1. Compose the URL
+			2. Make a Http Request to Apollo Server
+			3. Unmarshal the response
+			4. Get the particular key/value
+			4. Return back the value/error
+		//TODO Use the contentType to send the response
+	*/
+
+	// Compose the URL
+	pullConfigurationURL := composeURL()
+
+	// Make a Http Request to Apollo Server
+	resp, err := apolloClient.HTTPDo("GET", pullConfigurationURL, nil, nil)
+	if err != nil {
+		lager.Logger.Error("Error in Querying the Response from Apollo", err)
+		return nil, err
+	}
+
+	//Unmarshal the response
+	var body []byte
+	body, err = ioutil.ReadAll(resp.Body)
+	var configurations map[string]map[string]interface{}
+	error := serializers.Decode(defaultContentType, body, &configurations)
+	if error != nil {
+		lager.Logger.Error("Error in Unmarshalling the Response from Apollo", error)
+		return nil, err
+	}
+
+	//Find the particular Key
+	configList := configurations["configurations"]
+	configurationsValue, ok := configList[key]
+	if !ok {
+		lager.Logger.Error("Error in fetching the configurations for particular value", errors.New("No Key found : "+key))
+	}
+
+	lager.Logger.Debugf("The Key Value of : ", configurationsValue)
+	return configurationsValue, nil
+}
+
+// composeURL composes the URL based on the configurations given in chassis.yaml
+func composeURL() string {
+	pullConfigurationURL := strings.Replace(apolloServerAPI, ":ServerURL", config.GlobalDefinition.Cse.Config.Client.ServerURI, 1)
+	pullConfigurationURL = strings.Replace(pullConfigurationURL, ":appID", config.GlobalDefinition.Cse.Config.Client.ApolloServiceName, 1)
+	pullConfigurationURL = strings.Replace(pullConfigurationURL, ":clusterName", config.GlobalDefinition.Cse.Config.Client.ClusterName, 1)
+	pullConfigurationURL = strings.Replace(pullConfigurationURL, ":nameSpace", config.GlobalDefinition.Cse.Config.Client.ApolloNameSpace, 1)
+	return pullConfigurationURL
+}

--- a/apollo-client/apollo_client_test.go
+++ b/apollo-client/apollo_client_test.go
@@ -1,0 +1,155 @@
+package apolloclient
+
+import (
+	"encoding/json"
+	"github.com/ServiceComb/go-chassis/core/config"
+	"github.com/ServiceComb/go-chassis/core/config/model"
+	"github.com/ServiceComb/go-chassis/core/lager"
+	"github.com/stretchr/testify/assert"
+	"log"
+	"net/http"
+	"os"
+	"testing"
+)
+
+func TestApolloClient_NewApolloClient(t *testing.T) {
+
+}
+
+func TestApolloClient_HTTPDo(t *testing.T) {
+	keepAlive := map[string]interface{}{
+		"timeout": "500",
+	}
+	helper := startHttpServer(":9876", "/test", keepAlive)
+
+	lager.Initialize("", "INFO", "", "size", true, 1, 10, 7)
+	gopath := os.Getenv("GOPATH")
+	os.Setenv("CHASSIS_HOME", gopath+"src/github.com/ServiceComb/go-chassis/examples/discovery/server/")
+	config.Init()
+	config.GlobalDefinition = &model.GlobalCfg{}
+
+	apolloClient := &ApolloClient{}
+	apolloClient.NewApolloClient()
+
+	// Test existing API 's
+	resp, err := apolloClient.HTTPDo("GET", "http://127.0.0.1:9876/test", nil, nil)
+	assert.NotEqual(t, resp, nil)
+	assert.Equal(t, err, nil)
+
+	// Test Non-existing API's
+	resp, err = apolloClient.HTTPDo("GET", "http://127.0.0.1:9876/testUN", nil, nil)
+	assert.Equal(t, resp.StatusCode, 404)
+	assert.Equal(t, err, nil)
+
+	// Shutdown the helper server gracefully
+	if err := helper.Shutdown(nil); err != nil {
+		panic(err)
+	}
+}
+
+func TestApolloClient_PullConfig(t *testing.T) {
+	configurations := map[string]interface{}{
+		"timeout": "500",
+	}
+	configBody := map[string]interface{}{
+		"appId":          "TestApp",
+		"cluster":        "default",
+		"namespaceName":  "application",
+		"configurations": configurations,
+		"releaseKey":     "20180327130726-1dc5027439679153",
+	}
+
+	helper := startHttpServer(":9875", "/configs/TestApp/Default/application", configBody)
+
+	lager.Initialize("", "INFO", "", "size", true, 1, 10, 7)
+	gopath := os.Getenv("GOPATH")
+	os.Setenv("CHASSIS_HOME", gopath+"src/github.com/ServiceComb/go-chassis/examples/discovery/server/")
+	config.Init()
+	config.GlobalDefinition = &model.GlobalCfg{}
+
+	apolloClient := &ApolloClient{}
+	apolloClient.NewApolloClient()
+	config.GlobalDefinition.Cse.Config.Client.ServerURI = "http://127.0.0.1:9875"
+	config.GlobalDefinition.Cse.Config.Client.ApolloServiceName = "TestApp"
+	config.GlobalDefinition.Cse.Config.Client.ClusterName = "Default"
+	config.GlobalDefinition.Cse.Config.Client.ApolloNameSpace = "application"
+
+	//Test existing Services
+	configResponse, error := apolloClient.PullConfig("TestApp", "1.0", "SampleApp", "Default", "timeout", "")
+	assert.NotEqual(t, configResponse, nil)
+	assert.Equal(t, error, nil)
+
+	//Test the non-existing Key
+	configResponse, error = apolloClient.PullConfig("TestApp", "1.0", "SampleApp", "Default", "non-exsiting", "")
+	assert.Contains(t, error.Error(), "No Key found")
+
+	// Test the non-exsisting Service
+	config.GlobalDefinition.Cse.Config.Client.ApolloServiceName = "Non-exsitingAppID"
+	configResponse, error = apolloClient.PullConfig("TestApp", "1.0", "SampleApp", "Default", "non-exsiting", "")
+	assert.Contains(t, error.Error(), "Bad Response")
+
+	// Shutdown the helper server gracefully
+	if err := helper.Shutdown(nil); err != nil {
+		panic(err)
+	}
+
+}
+
+func TestApolloClient_PullConfigs(t *testing.T) {
+	configurations := map[string]interface{}{
+		"timeout": "500",
+	}
+	configBody := map[string]interface{}{
+		"appId":          "SampleApp",
+		"cluster":        "default",
+		"namespaceName":  "application",
+		"configurations": configurations,
+		"releaseKey":     "20180327130726-1dc5027439679153",
+	}
+
+	helper := startHttpServer(":9874", "/configs/SampleApp/Default/application", configBody)
+
+	lager.Initialize("", "INFO", "", "size", true, 1, 10, 7)
+	gopath := os.Getenv("GOPATH")
+	os.Setenv("CHASSIS_HOME", gopath+"src/github.com/ServiceComb/go-chassis/examples/discovery/server/")
+	config.Init()
+	config.GlobalDefinition = &model.GlobalCfg{}
+
+	apolloClient := &ApolloClient{}
+	apolloClient.NewApolloClient()
+	config.GlobalDefinition.Cse.Config.Client.ServerURI = "http://127.0.0.1:9874"
+	config.GlobalDefinition.Cse.Config.Client.ApolloServiceName = "SampleApp"
+	config.GlobalDefinition.Cse.Config.Client.ClusterName = "Default"
+	config.GlobalDefinition.Cse.Config.Client.ApolloNameSpace = "application"
+
+	//Test existing Services
+	configResponse, error := apolloClient.PullConfigs("SampleApp", "1.0", "SampleApp", "Default")
+	assert.NotEqual(t, configResponse, nil)
+	assert.Equal(t, error, nil)
+
+	//Test the non-existing Services
+	config.GlobalDefinition.Cse.Config.Client.ApolloServiceName = "Non-exsitingAppID"
+	configResponse, error = apolloClient.PullConfigs("SampleApp", "1.0", "SampleApp", "Default")
+	assert.Contains(t, error.Error(), "Bad Response")
+
+	// Shutdown the helper server gracefully
+	if err := helper.Shutdown(nil); err != nil {
+		panic(err)
+	}
+}
+
+func startHttpServer(port string, pattern string, responseBody map[string]interface{}) *http.Server {
+	helper := &http.Server{Addr: port}
+	http.HandleFunc(pattern, func(w http.ResponseWriter, r *http.Request) {
+
+		body, _ := json.Marshal(responseBody)
+		w.Write(body)
+	})
+
+	go func() {
+		if err := helper.ListenAndServe(); err != nil {
+			log.Printf("Httpserver: ListenAndServe() error: %s", err)
+		}
+	}()
+	return helper
+}


### PR DESCRIPTION
TODO
  - [x] Add implementation of ConfigClient for Apollo and Config-Server
  - [x] Init the ConfigClient Plugin on loading in go-chassis/config-center
  - [x] Update the Go-Archaius to use ConfigClient to pull configurations.
  - [x] Deprecate all the exsisting API implementation in Go-Archaius
  - [ ] Example for the complete Implementation 